### PR TITLE
Fix for permission denied errors when running client tools (#2)

### DIFF
--- a/kvm-client-wrapper
+++ b/kvm-client-wrapper
@@ -5,9 +5,8 @@ set -euo pipefail
 # "$0" will tell us which binary was executed. Now exec in the container instead
 BIN="$(basename $0)"
 ARGS="$@"
-USER_HOME="-v ${HOME:-"/"}:${HOME:-"/"}"
 RUN_LIBVIRT=$([[ -e /run/libvirt ]] && echo "-v /run/libvirt:/run/libvirt" || echo "")
 ETC_LIBVIRT_QEMU=$([[ -e /etc/libvirt/qemu ]] && echo "-v /etc/libvirt/qemu:/etc/libvirt/qemu" || echo "")
 LIBVIRT_IMAGES=$([[ -e /var/lib/libvirt/images ]] && echo "-v /var/lib/libvirt/images:/var/lib/libvirt/images" || echo "")
 
-exec podman run -it --rm --replace --net=host --userns=keep-id ${USER_HOME} ${RUN_LIBVIRT} ${ETC_LIBVIRT_QEMU} ${LIBVIRT_IMAGES} --name kvm-client-${BIN} %CONTAINER_IMAGE% ${BIN} ${ARGS}
+exec podman run -it --rm --replace --net=host --privileged ${RUN_LIBVIRT} ${ETC_LIBVIRT_QEMU} ${LIBVIRT_IMAGES} --name kvm-client-${BIN} %CONTAINER_IMAGE% ${BIN} ${ARGS}


### PR DESCRIPTION
Closes #2 

Return back to using a rootfull, privileged container

Running a rootless container was initially tested with crun which would allow secondary user groups to be passed into the user namespace of the rootless container. Since ALP is only supporting runc, we have to fall back to rootful execution of the client container as a limitation.